### PR TITLE
fix: :bug: fixed alerts in unwanted worlds

### DIFF
--- a/Source/ImprovedFactions/ImprovedFactions/src/main/java/io/github/toberocat/improvedfactions/listeners/OnChunkEntered.java
+++ b/Source/ImprovedFactions/ImprovedFactions/src/main/java/io/github/toberocat/improvedfactions/listeners/OnChunkEntered.java
@@ -33,6 +33,10 @@ public class OnChunkEntered implements Listener {
                 "faction-claimed");
         PlayerData playerData = ImprovedFactionsMain.playerData.get(event.getPlayer().getUniqueId());
 
+        if (!ImprovedFactionsMain.getPlugin().getConfig().getStringList("general.worlds").contains(event.getChunk().getWorld().getName())) {
+            return;
+        }
+
         if (UnclaimAutoChunkSubCommand.autoUnclaim.contains(event.getPlayer().getUniqueId()) && playerData.playerFaction != null) {
             Utils.UnClaimChunk(event.getPlayer());
         }


### PR DESCRIPTION
Tested this on a existing installation with MultiVerse and the alerts no longer appear in worlds it shouldn't